### PR TITLE
Add some configurations to pass TestInitScaleZero and TestActivatorHANonGraceful

### DIFF
--- a/test/lib.bash
+++ b/test/lib.bash
@@ -278,3 +278,19 @@ function trigger_gc_and_print_knative {
   echo ">>> Knative Services"
   oc get ksvc --all-namespaces
 }
+
+function wait_for_leader_controller() {
+  echo -n "Waiting for a leader Controller"
+  for i in {1..150}; do  # timeout after 5 minutes
+    local leader=$(oc get lease -n "${SERVING_NAMESPACE}" -ojsonpath='{range .items[*].spec}{"\n"}{.holderIdentity}' | cut -d"_" -f1 | grep "^controller-" | head -1)
+    # Make sure the leader pod exists.
+    if [ -n "${leader}" ] && oc get pod "${leader}" -n "${SERVING_NAMESPACE}"  >/dev/null 2>&1; then
+      echo -e "\nNew leader Controller has been elected"
+      return 0
+    fi
+    echo -n "."
+    sleep 2
+  done
+  echo -e "\n\nERROR: timeout waiting for leader controller"
+  return 1
+}

--- a/test/serving.bash
+++ b/test/serving.bash
@@ -35,7 +35,7 @@ function upstream_knative_serving_e2e_and_conformance_tests {
   prepare_knative_serving_tests || return $?
 
   # Enable allow-zero-initial-scale before running e2e tests (for test/e2e/initial_scale_test.go)
-  oc -n ${KNATIVE_SERVING_VERSION} patch knativeserving/knative-serving --type=merge --patch='{"spec": {"config": { "autoscaler": {"allow-zero-initial-scale": "true"}}}}'
+  oc -n ${SERVING_NAMESPACE} patch knativeserving/knative-serving --type=merge --patch='{"spec": {"config": { "autoscaler": {"allow-zero-initial-scale": "true"}}}}' || return $?
 
   local failed=0
   image_template="registry.svc.ci.openshift.org/openshift/knative-${KNATIVE_SERVING_VERSION}:knative-serving-test-{{.Name}}"


### PR DESCRIPTION
This patch adds some preparations for `TestInitScaleZero` and
`TestActivatorHANonGraceful`.

In a nutshell , it is same fix with nightly build's
https://github.com/openshift/knative-serving/pull/521 and https://github.com/openshift/knative-serving/pull/502.

https://github.com/openshift-knative/serverless-operator/pull/537 proved that upstream test passed with this change.